### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/flowtick/graphs.png?columns=all)](https://waffle.io/flowtick/graphs?utm_source=badge)
 graphs
 ======
 


### PR DESCRIPTION
Merge this to receive a badge indicating columns and number of cards in your columns on your waffle.io board at https://waffle.io/flowtick/graphs

This was requested by a real person (user adrobisch) on waffle.io, we're not trying to spam you.