### PR TITLE
(cats): add instance for traverse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,8 @@ lazy val commonSettings = Seq(
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0" ::
     Nil,
   autoAPIMappings := true,
-  siteSubdirName in ScalaUnidoc := "latest/api"
+  siteSubdirName in ScalaUnidoc := "latest/api",
+  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
 )
 
 lazy val core = (crossProject(JVMPlatform, JSPlatform) in file(".") / "core")

--- a/cats/jvm/src/test/scala/com/flowtick/graphs/cat/GraphCatsSpec.scala
+++ b/cats/jvm/src/test/scala/com/flowtick/graphs/cat/GraphCatsSpec.scala
@@ -1,6 +1,5 @@
 package com.flowtick.graphs.cat
 
-import cats.Applicative
 import com.flowtick.graphs._
 import com.flowtick.graphs.defaults._
 import cats.implicits._
@@ -51,13 +50,32 @@ class GraphCatsSpec extends AnyFlatSpec with Matchers {
 
     val numberGraph: Graph[Unit, Int] = Graph.fromEdges[Unit, Int](Set(1 --> 2, 2 --> 3))
 
-    val applied = Applicative[({ type GraphType[T] = Graph[Unit, T] })#GraphType]
-      .ap(functionGraph)(numberGraph)
+    val applied = GraphApplicative[Unit].ap(functionGraph)(numberGraph)
 
-    applied should be(
-      Graph.fromEdges[Unit, Int](
-        Set(2 --> 3, 3 --> 4) ++ Set(2 --> 4, 4 --> 6)
+    val expectedApplied = Graph.fromEdges[Unit, Int](
+      Set(2 --> 3, 3 --> 4) ++ Set(2 --> 4, 4 --> 6)
+    )
+
+    applied should be(expectedApplied)
+
+    val timesTenGraph = Graph.fromEdges[Unit, Int](
+      Set(
+        10 --> 20,
+        20 --> 30
       )
+    )
+
+    numberGraph.map(_ * 10) should be(timesTenGraph)
+  }
+
+  "Graph Traverse" should "traverse" in {
+    import com.flowtick.graphs.defaults.id.identifyAny
+
+    val numberGraph: Graph[Unit, Option[Int]] =
+      Graph.fromEdges[Unit, Int](Set(1 --> 2)).map(value => Some(value * 3))
+
+    GraphNodeTraverse[Unit].sequence(numberGraph) should be(
+      Some(Graph.fromEdges[Unit, Int](Set(3 --> 6)))
     )
   }
 

--- a/editor/jvm/src/test/scala/com/flowtick/graphs/RoutingFeatureSpec.scala
+++ b/editor/jvm/src/test/scala/com/flowtick/graphs/RoutingFeatureSpec.scala
@@ -30,12 +30,14 @@ class RoutingFeatureSpec extends EditorBaseSpec {
       case Some(posAfterAdd) =>
         posAfterAdd.x should be(100.0)
         posAfterAdd.y should be(100.0)
+      case None => fail()
     }
 
     moved.model.layout.nodeGeometry(firstNodeId) match {
       case Some(posAfterMove) =>
         posAfterMove.x should be(110.0)
         posAfterMove.y should be(110.0)
+      case None => fail()
     }
 
     val edgeAfterMove = moved.model.graph.findEdge(edgeId)


### PR DESCRIPTION
attempt to implement a traverse on graphs by capturing the old ids
and mapping the edges accordingly

addes kind projector to simplify signatures