### PR TITLE
(core): add edge id

### DIFF
--- a/cats/jvm/src/test/scala/com/flowtick/graphs/cat/GraphCatsSpec.scala
+++ b/cats/jvm/src/test/scala/com/flowtick/graphs/cat/GraphCatsSpec.scala
@@ -3,10 +3,11 @@ package com.flowtick.graphs.cat
 import com.flowtick.graphs._
 import com.flowtick.graphs.defaults._
 import cats.implicits._
+import org.scalatest.diagrams.Diagrams
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class GraphCatsSpec extends AnyFlatSpec with Matchers {
+class GraphCatsSpec extends AnyFlatSpec with Matchers with Diagrams {
   import com.flowtick.graphs.cat.instances._
 
   "Graph Monoid" should "combine graphs" in {

--- a/core/jvm/src/test/scala/com/flowtick/graphs/GraphSpec.scala
+++ b/core/jvm/src/test/scala/com/flowtick/graphs/GraphSpec.scala
@@ -91,7 +91,7 @@ class GraphSpec extends AnyFlatSpec with Matchers {
 
   it should "have nodes after adding an edge" in {
     val intGraph =
-      Graph.empty[Option[Unit], Int].withEdgeValue(None, Node.of(1), Node.of(2))
+      Graph.empty[Option[Unit], Int].addEdge(None, 1, 2)
     intGraph.nodes should contain theSameElementsAs List(
       Node("1", 1),
       Node("2", 2)
@@ -109,7 +109,7 @@ class GraphSpec extends AnyFlatSpec with Matchers {
       .addNode(node3)
 
     intGraph.removeNodeValue(node3) should be(
-      Graph.empty[Unit, Int].withEdgeValue((), Node.of(1), Node.of(2))
+      Graph.empty[Unit, Int].addEdge((), 1, 2)
     )
 
     val expected = Graph
@@ -123,8 +123,8 @@ class GraphSpec extends AnyFlatSpec with Matchers {
   it should "remove edges" in {
     val intGraph = Graph
       .empty[Unit, Int]
-      .withEdgeValue((), Node.of(1), Node.of(2))
-      .withNode(Node.of(3))
+      .addEdge((), 1, 2)
+      .addNode(3)
 
     val expected = Graph
       .empty[Unit, Int]

--- a/core/shared/src/main/scala/com/flowtick/graphs/defaults/package.scala
+++ b/core/shared/src/main/scala/com/flowtick/graphs/defaults/package.scala
@@ -8,6 +8,14 @@ package object defaults {
   implicit val identifiableInt: Identifiable[Int] =
     Identifiable.identify(int => int.toString)
 
+  private final case class IdentifiableOption[T](id: Identifiable[T])
+      extends Identifiable[Option[T]] {
+    override def apply(value: Option[T]): String = value.map(id(_)).getOrElse("none")
+  }
+
+  implicit def identifiableOption[T](implicit id: Identifiable[T]): Identifiable[Option[T]] =
+    IdentifiableOption(id)
+
   object id {
     implicit val identifyAny: Identifiable[Any] = (value: Any) => value.toString
   }

--- a/editor/shared/src/main/scala/com/flowtick/graphs/editor/EditorGraph.scala
+++ b/editor/shared/src/main/scala/com/flowtick/graphs/editor/EditorGraph.scala
@@ -57,6 +57,10 @@ object EditorGraphNode {
 }
 
 object EditorGraphEdge {
+  implicit val identifiableEditorEdge = new Identifiable[EditorGraphEdge] {
+    override def apply(value: EditorGraphEdge): String = value.id
+  }
+
   implicit val editorEdgeStyleRef: StyleRef[Edge[EditorGraphEdge]] =
     new StyleRef[Edge[EditorGraphEdge]] {
       override def id(element: Edge[EditorGraphEdge]): Option[String] = Some(

--- a/editor/shared/src/main/scala/com/flowtick/graphs/editor/EditorModel.scala
+++ b/editor/shared/src/main/scala/com/flowtick/graphs/editor/EditorModel.scala
@@ -5,7 +5,7 @@ import cats.data.ValidatedNel
 import com.flowtick.graphs.Graph
 import com.flowtick.graphs.graphml.{Datatype, GraphMLKey}
 import com.flowtick.graphs.json.schema.Schema
-import com.flowtick.graphs.layout.{GraphLayout, GraphLayoutLike, GraphLayouts}
+import com.flowtick.graphs.layout.{GraphLayoutLike, GraphLayouts}
 import com.flowtick.graphs.style._
 import io.circe.Json
 

--- a/graphml/jvm/src/test/scala/com/flowtick/graphs/graphml/GraphMLDatatypeSpec.scala
+++ b/graphml/jvm/src/test/scala/com/flowtick/graphs/graphml/GraphMLDatatypeSpec.scala
@@ -199,7 +199,9 @@ class GraphMLDatatypeSpec extends AnyFlatSpec with Matchers {
         ) should contain theSameElementsAs graphML.graph.nodes.map(_.id)
         parsedGraph.graph.edges.map(
           _.id
-        ) should contain theSameElementsAs graphML.graph.edges.map(_.id)
+        ) should contain theSameElementsAs graphML.graph.edges.map { edge =>
+          s"${edge.from}-${edge.to}"
+        }
 
       case Left(errors) => fail(s"parsing errors ${errors.toString}")
     }

--- a/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/GraphMLDatatype.scala
+++ b/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/GraphMLDatatype.scala
@@ -41,8 +41,11 @@ final case class GraphMLProperty(
 class GraphMLDatatype[E, N](
     nodeDataType: Datatype[GraphMLNode[N]],
     edgeDataType: Datatype[GraphMLEdge[E]]
-)(implicit edgeLabel: Labeled[Edge[GraphMLEdge[E]], String])
-    extends Datatype[GraphMLGraph[E, N]] {
+)(implicit
+    edgeLabel: Labeled[Edge[GraphMLEdge[E]], String],
+    nodeId: Identifiable[GraphMLNode[N]],
+    edgeId: Identifiable[GraphMLEdge[E]]
+) extends Datatype[GraphMLGraph[E, N]] {
   val nodeTargetHint = Some("node")
   val edgeTargetHint = Some("edge")
   val metaTargetHint = Some("meta")
@@ -130,7 +133,7 @@ class GraphMLDatatype[E, N](
       resources: Seq[GraphMLResource]
   ): Validated[NonEmptyList[Throwable], GraphMLGraph[E, N]] =
     parseGraphNodes(graph, graphKeys).andThen { parsedGraph =>
-      parseEdges(parsedGraph.edgesXml, parsedGraph.nodes, graphKeys).andThen { edges =>
+      parseEdges(parsedGraph.edgesXml, graphKeys).andThen { edges =>
         valid(
           GraphMLGraph(
             Graph(edges, parsedGraph.nodes.values),
@@ -142,7 +145,6 @@ class GraphMLDatatype[E, N](
 
   protected def parseEdges(
       edgeXmlNodes: List[scala.xml.Node],
-      nodes: scala.collection.Map[String, Node[GraphMLNode[N]]],
       keys: scala.collection.Map[String, GraphMLKey]
   ): Validated[NonEmptyList[Throwable], List[Edge[GraphMLEdge[E]]]] = {
     edgeXmlNodes.map { edgeNode =>
@@ -224,7 +226,8 @@ class GraphMLDatatype[E, N](
 
 object GraphMLDatatype {
   def apply[E, N](implicit
-      identifiable: Identifiable[GraphMLNode[N]],
+      nodeId: Identifiable[GraphMLNode[N]],
+      edgeId: Identifiable[GraphMLEdge[E]],
       edgeLabel: Labeled[Edge[GraphMLEdge[E]], String],
       nodeDataType: Datatype[N],
       edgeDataType: Datatype[E]

--- a/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/GraphMLGraph.scala
+++ b/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/GraphMLGraph.scala
@@ -1,7 +1,7 @@
 package com.flowtick.graphs.graphml
 
 import com.flowtick.graphs.layout.{DefaultGeometry, EdgePath, Geometry}
-import com.flowtick.graphs.{Edge, Graph, Node, Relation}
+import com.flowtick.graphs.{Edge, Graph, Identifiable, Node, Relation}
 import com.flowtick.graphs.style._
 
 final case class GraphMLKey(
@@ -96,7 +96,10 @@ final case class GraphMLMeta(
 )
 
 object GraphML {
-  def empty[E, N]: GraphMLGraph[E, N] = GraphMLGraph[E, N](
+  def empty[E, N](implicit
+      nodeId: Identifiable[GraphMLNode[N]],
+      edgeId: Identifiable[GraphMLEdge[E]]
+  ): GraphMLGraph[E, N] = GraphMLGraph[E, N](
     Graph.empty[GraphMLEdge[E], GraphMLNode[N]],
     GraphMLMeta()
   )
@@ -106,12 +109,18 @@ object GraphML {
       edges: Iterable[Edge[GraphMLEdge[E]]],
       nodes: Iterable[Node[GraphMLNode[N]]] = Iterable.empty,
       keys: Seq[GraphMLKey] = Seq.empty
+  )(implicit
+      nodeId: Identifiable[GraphMLNode[N]],
+      edgeId: Identifiable[GraphMLEdge[E]]
   ): GraphMLGraph[E, N] = {
     GraphMLGraph(Graph(edges = edges, nodes = nodes), GraphMLMeta(keys = keys))
   }
 
   def fromEdges[E, N](
       edges: Iterable[Relation[GraphMLEdge[E], GraphMLNode[N]]]
+  )(implicit
+      nodeId: Identifiable[GraphMLNode[N]],
+      edgeId: Identifiable[GraphMLEdge[E]]
   ): GraphMLGraph[E, N] =
     GraphMLGraph(Graph.fromEdges(edges), GraphMLMeta())
 }

--- a/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/package.scala
+++ b/graphml/shared/src/main/scala/com/flowtick/graphs/graphml/package.scala
@@ -10,7 +10,7 @@ import xmls.XMLS
 import scala.collection.GenTraversable
 import scala.reflect.ClassTag
 import scala.util.{Either, Left, Right}
-import scala.xml.{Elem, NodeSeq, Text}
+import scala.xml.{Elem, NodeSeq}
 
 package object graphml {
   trait Serializer[T] {
@@ -333,7 +333,8 @@ package object graphml {
   }
 
   implicit def graphMLDataType[E, N](implicit
-      identifiable: Identifiable[GraphMLNode[N]],
+      nodeId: Identifiable[GraphMLNode[N]],
+      edgeId: Identifiable[GraphMLEdge[E]],
       edgeLabel: Labeled[Edge[GraphMLEdge[E]], String],
       nodeDataType: Datatype[N],
       edgeDataType: Datatype[E]
@@ -361,6 +362,9 @@ package object graphml {
 
   implicit def graphMLNodeIdentifiable[N]: Identifiable[GraphMLNode[N]] =
     (node: GraphMLNode[N]) => node.id
+
+  implicit def graphMLEdgeIdentifiable[E]: Identifiable[GraphMLEdge[E]] =
+    (edge: GraphMLEdge[E]) => edge.id
 
   implicit def graphMLEdgeLabel[V, N]: Labeled[Edge[GraphMLEdge[V]], String] =
     (edge: Edge[GraphMLEdge[V]]) => edge.value.id
@@ -443,7 +447,7 @@ package object graphml {
           labelValue = edgeLabel(edge)
         )
 
-        Edge.of(mlEdge, edge.from, edge.to)
+        Edge(edge.id, mlEdge, edge.from, edge.to)
       }
 
       GraphMLGraph(Graph(edges = mlEdges, nodes = mlNodes), GraphMLMeta())

--- a/json/shared/src/main/scala/com/flowtick/graphs/json/package.scala
+++ b/json/shared/src/main/scala/com/flowtick/graphs/json/package.scala
@@ -17,23 +17,23 @@ package object json {
 
       import io.circe.generic.semiauto._
 
-      implicit def nodeEncoder[N](implicit
+      implicit def wrappedNodeEncoder[N](implicit
           nodeEncoder: Encoder[N]
       ): Encoder[Node[N]] = deriveEncoder[Node[N]]
-      implicit def nodeDecoder[N](implicit
+      implicit def wrappedNodeDecoder[N](implicit
           nodeDecoder: Decoder[N]
       ): Decoder[Node[N]] = deriveDecoder[Node[N]]
 
-      implicit def edgeEncoder[E, N](implicit
+      implicit def wrappedEdgeEncoder[E, N](implicit
           edgeEncoder: Encoder[E]
       ): Encoder[Edge[E]] = graphsEdgeEncoder[E, N]
-      implicit def edgeDecoder[E, N](implicit
+      implicit def wrappedEdgeDecoder[E, N](implicit
           edgeDecoder: Decoder[E]
       ): Decoder[Edge[E]] = deriveDecoder[Edge[E]]
 
       implicit def defaultGraphEncoder[E, N](implicit
-          nodesEncoder: Encoder[Node[N]],
-          edgesEncoder: Encoder[Edge[E]]
+          nodeEncoder: Encoder[Node[N]],
+          edgeEncoder: Encoder[Edge[E]]
       ): Encoder[Graph[E, N]] = new Encoder[Graph[E, N]] {
         override def apply(a: Graph[E, N]): Json = {
           val fields = new ListBuffer[(String, Json)]
@@ -44,9 +44,10 @@ package object json {
       }
 
       implicit def defaultGraphDecoder[E, N](implicit
-          nodesDecoder: Decoder[Node[N]],
+          nodeDecoder: Decoder[Node[N]],
           edgeDecoder: Decoder[Edge[E]],
-          nodeId: Identifiable[N]
+          nodeId: Identifiable[N],
+          edgeId: Identifiable[E]
       ): Decoder[Graph[E, N]] = new Decoder[Graph[E, N]] {
         override def apply(c: HCursor): Result[Graph[E, N]] = for {
           nodes <- c
@@ -87,16 +88,17 @@ package object json {
           nodeDecoder: Decoder[N]
       ): Decoder[Node[N]] = deriveDecoder[Node[N]]
 
-      implicit def edgeEncoder[E, N](implicit
+      implicit def wrappedEdgeEncoder[E, N](implicit
           edgeEncoder: Encoder[E]
       ): Encoder[Edge[E]] = graphsEdgeEncoder[E, N]
-      implicit def edgeDecoder[E, N](implicit
+
+      implicit def wrappedEdgeDecoder[E, N](implicit
           edgeDecoder: Decoder[E]
       ): Decoder[Edge[E]] = deriveDecoder[Edge[E]]
 
       implicit def embeddedGraphEncoder[E, N](implicit
-          nodesEncoder: Encoder[N],
-          edgesEncoder: Encoder[Edge[E]]
+          nodeEncoder: Encoder[N],
+          edgeEncoder: Encoder[E]
       ): Encoder[Graph[E, N]] = new Encoder[Graph[E, N]] {
         override def apply(a: Graph[E, N]): Json = Json
           .obj(
@@ -107,10 +109,10 @@ package object json {
       }
 
       implicit def embeddedGraphDecoder[E, N](implicit
-          nodesDecoder: Decoder[N],
+          nodeDecoder: Decoder[N],
           edgeDecoder: Decoder[E],
-          edgesDecoder: Decoder[Edge[E]],
-          nodeId: Identifiable[N]
+          nodeId: Identifiable[N],
+          edgeId: Identifiable[E]
       ): Decoder[Graph[E, N]] = new Decoder[Graph[E, N]] {
         override def apply(c: HCursor): Result[Graph[E, N]] = for {
           nodes <- c.downField("nodes").as[List[N]]


### PR DESCRIPTION
- making the edge identifiable allows for multigraphs
- allow to add edge value with node ids
- remove implicit name overlap in json support
- less complex cats traverse